### PR TITLE
xenserver/xenserver-* - fixed guest_os_type for VMware  provider

### DIFF
--- a/xenserver/xenserver-6.2.0-x86_64.json
+++ b/xenserver/xenserver-6.2.0-x86_64.json
@@ -44,7 +44,7 @@
             "boot_wait": "5s",
             "headless": false,
             "disk_size": 51200,
-            "guest_os_type": "RedHat_64",
+            "guest_os_type": "rhel5-64",
             "http_directory": "http",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "md5",

--- a/xenserver/xenserver-6.5.0-x86_64.json
+++ b/xenserver/xenserver-6.5.0-x86_64.json
@@ -44,7 +44,7 @@
             "boot_wait": "5s",
             "headless": false,
             "disk_size": 51200,
-            "guest_os_type": "RedHat_64",
+            "guest_os_type": "rhel5-64",
             "http_directory": "http",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "md5",

--- a/xenserver/xenserver-7.0.0-x86_64.json
+++ b/xenserver/xenserver-7.0.0-x86_64.json
@@ -44,7 +44,7 @@
             "boot_wait": "5s",
             "headless": false,
             "disk_size": 51200,
-            "guest_os_type": "RedHat_64",
+            "guest_os_type": "rhel5-64",
             "http_directory": "http",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "md5",

--- a/xenserver/xenserver-7.1.0-sp1-x86_64.json
+++ b/xenserver/xenserver-7.1.0-sp1-x86_64.json
@@ -44,7 +44,7 @@
             "boot_wait": "5s",
             "headless": false,
             "disk_size": 51200,
-            "guest_os_type": "RedHat_64",
+            "guest_os_type": "rhel5-64",
             "http_directory": "http",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "md5",

--- a/xenserver/xenserver-7.2.0-x86_64.json
+++ b/xenserver/xenserver-7.2.0-x86_64.json
@@ -44,7 +44,7 @@
             "boot_wait": "5s",
             "headless": false,
             "disk_size": 51200,
-            "guest_os_type": "RedHat_64",
+            "guest_os_type": "rhel5-64",
             "http_directory": "http",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "md5",


### PR DESCRIPTION
The packer builds failed on VMware Fusion when provisioning the VM. 

Found at https://github.com/hashicorp/packer/issues/1943 that guest_os_type values are different for VMWare Fusion provider.